### PR TITLE
fix: tracking of wrong side for capture

### DIFF
--- a/just-the-chess/src/Game.ts
+++ b/just-the-chess/src/Game.ts
@@ -150,7 +150,7 @@ class GameImpl implements Game {
       _currentTurn: observable,
       _toggleTurn: action,
       _stateIndex: observable,
-      _actions: observable,
+      _actions: observable.shallow,
       _applyResolution: action
     })
 

--- a/just-the-chess/src/game/Board.ts
+++ b/just-the-chess/src/game/Board.ts
@@ -432,7 +432,7 @@ class BoardImpl implements BoardInternal {
         this._tracking[side].trackPromotion(r.to, mode)
       } 
       if (r.action.includes('capture')) {
-        this._tracking[side].trackCapture(r.captured!, r.to, mode)
+        this._tracking[r.captured!.side].trackCapture(r.captured!, r.to, mode)
       }
       if (r.action === 'move' || r.action.includes('capture')) {
         this._tracking[side].trackPositionChange(r, mode)
@@ -542,7 +542,7 @@ class BoardImpl implements BoardInternal {
 
 
   _dumpTracking(): void {
-    console.log(this._tracking)
+    console.log("TRACKING " + '\n' +  JSON.stringify(this._tracking, null, 2))
   }
   _syncTrackingTest(): void {
     const target = new Tracking()


### PR DESCRIPTION
.

Unrelated:
made `game._action: observable.shallow` since we're only ever observing its length