### PR TITLE
Core: ActionRecord as class; GameStatus improvements; type RookSide

### DIFF
--- a/apps/chess-rn/src/app/Menu.tsx
+++ b/apps/chess-rn/src/app/Menu.tsx
@@ -103,9 +103,8 @@ const Menu: React.FC<{
         >auto-swap</MenuCheckboxItem>
         <MenuSectionTitle>Game</MenuSectionTitle>
         {(game.playing) && (<>
-          <MenuItem onClick={game.callADraw} icon={{icon: '=', style: {fontSize: 26, fontWeight: '300'}}}>call a draw</MenuItem>
+          <MenuItem onClick={game.offerADraw} icon={{icon: '=', style: {fontSize: 26, fontWeight: '300'}}}>offer a draw</MenuItem>
           <MenuItem onClick={game.concede} icon={{icon: currentConcedes, style: {fontSize: 17, fontWeight: '300'}}}>{game.currentTurn} concedes</MenuItem>
-          <MenuItem onClick={game.checkStalemate} icon={{icon: '\u0024?', style: {fontSize: 22, fontWeight: '300'}}}>check for stalemate</MenuItem>
         </>)}
         <MenuItem onClick={game.reset} icon={{icon: '\u21ba', style: {fontSize: 32}}}>reset</MenuItem>
       </MenuItemsOuter>

--- a/apps/chess-web/src/app/Dash.tsx
+++ b/apps/chess-web/src/app/Dash.tsx
@@ -38,7 +38,7 @@ const Dash: React.FC<{
 }) => {
 
   const game = useGame()
-  const [showMoves, setShowMoves] = useState<boolean>(false)
+  const [showMoves, setShowMoves] = useState<boolean>(true)
 
   const handleSetShowMoves = (checked: boolean) => {
     setShowMoves(checked)

--- a/apps/chess-web/src/app/widgets/MainMenu.tsx
+++ b/apps/chess-web/src/app/widgets/MainMenu.tsx
@@ -75,7 +75,7 @@ const AppMenubar: React.FC<{
         <MenubarTrigger>Game</MenubarTrigger>
         <MenubarPopup>
         {(game.playing) && (<>
-          <MenubarItem onClick={game.callADraw} icon={menuIcons.draw}>call a draw</MenubarItem>
+          <MenubarItem onClick={game.offerADraw} icon={menuIcons.draw}>offer a draw</MenubarItem>
           <MenubarItem onClick={game.concede} icon={{icon: currentConcedes, style: (menuIcons.concede as IconAndStyles).style}}>{game.currentTurn} concedes</MenubarItem>
         </>)}
           <MenubarItem onClick={game.reset} icon={menuIcons.reset}>reset</MenubarItem>

--- a/apps/chess-web/src/app/widgets/SideMenu.tsx
+++ b/apps/chess-web/src/app/widgets/SideMenu.tsx
@@ -79,7 +79,7 @@ const SideMenu: React.FC<{
         <MenuSectionTitle>Game</MenuSectionTitle>
         <hr />
         {(game.playing) && (<>
-          <MenuItem onClick={game.callADraw} icon={menuIcons.draw}>call a draw</MenuItem>
+          <MenuItem onClick={game.offerADraw} icon={menuIcons.draw}>offer a draw</MenuItem>
           <MenuItem onClick={game.concede} icon={{icon: currentConcedes, style: (menuIcons.concede as IconAndStyles).style}}>{game.currentTurn} concedes</MenuItem>
         </>)}
         <MenuItem onClick={game.reset} icon={menuIcons.reset}>reset</MenuItem>

--- a/apps/chess-web/src/services/MessagesStore.ts
+++ b/apps/chess-web/src/services/MessagesStore.ts
@@ -7,13 +7,12 @@ import {
 
 import { 
   type Action,
-  type ActionRecord,
+  ActionRecord,
   type Move,
   type Check,  
   type Side, 
   type GameStatus,
   type ChessListener,
-  actionRecordToLAN, 
   positionToString,
 } from '@artemis-prime/chess-core'
 
@@ -96,20 +95,20 @@ class MessageStore implements ChessListener {
   actionResolved(m: Move, action: Action | null): void { }
 
   actionTaken(r: ActionRecord): void {
-    this._pushMessage({message: actionRecordToLAN(r), type: r.action, actionRecord: r}) 
+    this._pushMessage({message: r.toLANString(), type: r.action, actionRecord: r}) 
   }
 
   actionsRestored(recs: readonly ActionRecord[]): void {
     recs.forEach((r) => {
-      this._pushMessage({message: actionRecordToLAN(r), type: r.action, actionRecord: r}) 
+      this._pushMessage({message: r.toLANString(), type: r.action, actionRecord: r}) 
     })
   }
 
   actionUndone(r: ActionRecord): void {
-    this._pushMessage({message: actionRecordToLAN(r), type: 'undo', actionRecord: r}) 
+    this._pushMessage({message: r.toLANString(), type: 'undo', actionRecord: r}) 
   }
   actionRedone (r: ActionRecord): void {
-    this._pushMessage({message: actionRecordToLAN(r), type: 'redo', actionRecord: r}) 
+    this._pushMessage({message: r.toLANString(), type: 'redo', actionRecord: r}) 
   }
 }
 

--- a/just-the-chess/src/ActionRecord.ts
+++ b/just-the-chess/src/ActionRecord.ts
@@ -1,5 +1,4 @@
 import type Action from './Action'
-import { type MoveResult, MOVERESULT_FROM_SYMBOL, MOVERESULT_SYMBOLS, MOVERESULTS } from './GameStatus'
 import type Move from './Move'
 import type Piece from './Piece'
 import { 
@@ -13,118 +12,123 @@ import {
 } from './Piece'
 import { positionToString, positionFromString } from './Position'
 
+type AnnotatedResult =  'checkmate' | 'stalemate' |  'check'
 
-  // Describes a change of state.
-  // Must contain enough info to undo and redo the change 
-interface ActionRecord extends Move {
+const ANNOTATION_FROM_RESULT = {
+  check: '+',
+  checkmate: '#',
+  stalemate: '==',
+} as {[key in AnnotatedResult]: string}
+
+const ANNOTATIONS = Object.values(ANNOTATION_FROM_RESULT)
+const ANNOTATEDRESULTS = Object.keys(ANNOTATION_FROM_RESULT) as AnnotatedResult[]
+
+  // Use to record a change of state.
+  // Must contain enough info to undo and redo said change. 
+class ActionRecord {
+
+  readonly move: Move
   readonly action: Action
-    // Both are needed to 'undo' or 'redo' a 'capturePromote' Action.
-    // Required if action is 'capture'. Needed for 'undo' 
-  readonly captured?: Piece
-  moveResult?: MoveResult
-}
+  readonly captured?: Piece         // needed to undo a 'capture'
+  annotatedResult?: AnnotatedResult // stored here to follow notation conventions
 
-
-// Something like "long algebraic notation" cf: https://en.wikipedia.org/wiki/Algebraic_notation_(chess)
-const actionRecordToLAN = (r: ActionRecord, verbose?: boolean): string => {
-
-  if (r.action === 'castle') {
-    return verbose ? 
-      `${r.piece.side} castles ${r.to.file === 'g' ? 'kingside' : 'queenside'}`
-      :
-      `${r.piece.side === 'white' ? 'w' : 'b'}${r.to.file === 'g' ? '0-0' : '0-0-0'}`
+  constructor(move: Move, action: Action, captured?: Piece, annotatedResult?: AnnotatedResult) {
+    this.move = move
+    this.action = action
+    this.captured = captured
+    this.annotatedResult = annotatedResult
   }
 
-  let str = verbose ? 
-    `${pieceToString(r.piece, 'side Type')} (${positionToString(r.to)}) `
-    :
-    pieceToString(r.piece, 'sT') + positionToString(r.from)
+  toLANString(): string {
 
-  switch (r.action) {
-    case 'capture':
-      str += verbose ?
-        `captures ${r.captured!.type} (${positionToString(r.to)})`
-        :
-        `x${PIECETYPE_NAMES[r.captured!.type].short}${positionToString(r.to)}`
-    break
-    case 'move':
-      str += verbose ?
-        `moves to ${positionToString(r.to)}`
-        :
-        positionToString(r.to)
-    break
-    case 'promote':
-      str += verbose ?
-        `is promoted to a queen at (${positionToString(r.to)})`
-        :
-        `${positionToString(r.to)}=Q`
-    break
-    case 'capturePromote':
-      str += verbose ?
-        `captures ${r.captured!.type} and is promoted to a queen at (${positionToString(r.to)})`
-        :
-        `x${PIECETYPE_NAMES[r.captured!.type].short}${positionToString(r.to)}=Q`
-    break
-  } 
-
-  if (r.moveResult) {
-    str += verbose ? ` resulting in ${r.moveResult}` : MOVERESULT_FROM_SYMBOL[r.moveResult]
-  }
-
-  return str
-}
-
-const lanToActionRecord = (lan: string, note?: any): ActionRecord => {
-
-  const castleRecordIfCastle = (): ActionRecord | undefined => {
-    if (!lan.includes('0-0')) return undefined
-
-    const toFile = lan.includes('0-0-0') ? 'c' : 'g'
-    const side = (lan.charAt(0) === 'w') ? 'white' : 'black'
-    const rank = (side === 'white') ? 1 : 8
-    return {
-      piece: {type: 'king', side},
-      to: {rank, file: toFile},  
-      from: {rank, file: 'e'},
-      action: 'castle'
+    if (this.action === 'castle') {
+      return `${this.move.piece.side === 'white' ? 'w' : 'b'}${this.move.to.file === 'g' ? '0-0' : '0-0-0'}`
     }
+  
+    let str = pieceToString(this.move.piece, 'sT') + positionToString(this.move.from)
+  
+    switch (this.action) {
+      case 'capture':
+        str += `x${PIECETYPE_NAMES[this.captured!.type].short}${positionToString(this.move.to)}`
+      break
+      case 'move':
+        str += positionToString(this.move.to)
+      break
+      case 'promote':
+        str += `${positionToString(this.move.to)}=Q`
+      break
+      case 'capturePromote':
+        str += `x${PIECETYPE_NAMES[this.captured!.type].short}${positionToString(this.move.to)}=Q`
+      break
+    } 
+  
+    if (this.annotatedResult) {
+      str += ANNOTATION_FROM_RESULT[this.annotatedResult]
+    }
+  
+    return str
   }
 
-  const castleRecord = castleRecordIfCastle()
-  if (castleRecord) return castleRecord
+  static fromLANString = (lan: string): ActionRecord => {
 
-  const piece = pieceFromCodeString(lan.slice(0,2))
-  const from = positionFromString(lan.slice(2,4))
-  const isCapture = lan.charAt(4) === 'x'
-  const captured = isCapture ? {type: PIECETYPE_FROM_CODE[lan.charAt(5) as PieceTypeCode] as PieceType, side: otherSide(piece!.side)} : undefined
-  const toPositionIndex = (isCapture) ? 6 : 4
-  const to = positionFromString(lan.slice(toPositionIndex, toPositionIndex + 2))
-  const isPromote = lan.slice(toPositionIndex + 2, 2) === '=Q'
-
-  let index = -1
-  MOVERESULT_SYMBOLS.every((el, i) => {
-    if (lan.endsWith(el)) {
-      index = i
-      return false
-    }  
-    return true
-  })
-  const moveResult = (index === -1) ? undefined : MOVERESULTS[index]
-
-
-  if (!piece) throw new Error('lanToActionRecord(): error parsing piece! (note: ' + note.toString() + ')')
-  if (!from) throw new Error('lanToActionRecord(): error parsing from poistion! (note: ' + note.toString() + ')')
-  if (!to) throw new Error('lanToActionRecord(): error parsing to poistion! (note: ' + note.toString() + ')')
-
-  let action: Action
-  if (isCapture) {
-    action = isPromote ? 'capturePromote' : 'capture' 
+    if (lan.includes('0-0')) {
+      const toFile = lan.includes('0-0-0') ? 'c' : 'g'
+      const side = (lan.charAt(0) === 'w') ? 'white' : 'black'
+      const rank = (side === 'white') ? 1 : 8
+      return new ActionRecord(
+        {
+          piece: {type: 'king', side},
+          to: {rank, file: toFile},  
+          from: {rank, file: 'e'},
+        },
+        'castle' 
+      )
+    }
+  
+    const piece = pieceFromCodeString(lan.slice(0,2))
+    const from = positionFromString(lan.slice(2,4))
+    const isCapture = lan.charAt(4) === 'x'
+    const captured = isCapture ? {type: PIECETYPE_FROM_CODE[lan.charAt(5) as PieceTypeCode] as PieceType, side: otherSide(piece!.side)} : undefined
+    const toPositionIndex = (isCapture) ? 6 : 4
+    const to = positionFromString(lan.slice(toPositionIndex, toPositionIndex + 2))
+    const isPromote = lan.slice(toPositionIndex + 2, 2) === '=Q'
+  
+    let index = -1
+    ANNOTATIONS.every((el, i) => {
+      if (lan.endsWith(el)) {
+        index = i
+        return false
+      }  
+      return true
+    })
+    const annotatedResult = (index === -1) ? undefined : ANNOTATEDRESULTS[index]
+    
+    if (!piece) throw new Error('lanToActionRecord(): error parsing piece!')
+    if (!from) throw new Error('lanToActionRecord(): error parsing from poistion!')
+    if (!to) throw new Error('lanToActionRecord(): error parsing to poistion!')
+  
+    let action: Action
+    if (isCapture) {
+      action = isPromote ? 'capturePromote' : 'capture' 
+    }
+    else {
+      action = isPromote ? 'promote' : 'move'
+    }
+  
+    return new ActionRecord(
+      { piece, to, from }, 
+      action, 
+      captured, 
+      annotatedResult
+    )
   }
-  else {
-    action = isPromote ? 'promote' : 'move'
-  }
-
-  return {piece, to, from, action, captured, moveResult}
 }
 
-export { type ActionRecord as default, actionRecordToLAN, lanToActionRecord }
+
+export { 
+  ActionRecord as default,
+  type AnnotatedResult,
+  ANNOTATION_FROM_RESULT,
+  ANNOTATIONS,
+  ANNOTATEDRESULTS,
+}

--- a/just-the-chess/src/ChessListener.ts
+++ b/just-the-chess/src/ChessListener.ts
@@ -1,5 +1,5 @@
 import type Action from './Action'
-import type ActionRecord from './ActionRecord'
+import ActionRecord from './ActionRecord'
 import type Check from './Check'
 import type GameStatus from './GameStatus'
 import type Move from './Move' 

--- a/just-the-chess/src/GameStatus.ts
+++ b/just-the-chess/src/GameStatus.ts
@@ -1,32 +1,25 @@
 import {type Side} from './Piece'
+import {type AnnotatedResult} from './ActionRecord'
 
-type MoveResult =  'checkmate' | 'stalemate' |  'check'
-
-const MOVERESULT_FROM_SYMBOL = {
-  check: '+',
-  checkmate: '#',
-  stalemate: '==',
-} as {[key in MoveResult]: string}
-
-const MOVERESULT_SYMBOLS = Object.values(MOVERESULT_FROM_SYMBOL)
-const MOVERESULTS = Object.keys(MOVERESULT_FROM_SYMBOL) as MoveResult[]
 
 const GAMERESULT_SYMBOLS = {
   victor: {
-    white: '0-1',
-    black: '1-0',
-    draw: '='
+    white: '1-0',
+    black: '0-1',
+    draw: '½–½'
   },
-  agreement: ' (agr.)'
+  offer: ' (offer)',
+  concession: ' (con)'
 }
 
   // https://www.britannica.com/topic/chess
   // For our purposes, 'draw' covers anything but 'stalemate', 
   // and is set by user action (not calculated) 
-type GameState = 'new' | 'restored' |'resumed' | 'draw' | 'conceded' | Omit<MoveResult, 'check'>
+type GameState = 'new' | 'restored' |'resumed' | 'draw' | 'conceded' | Omit<AnnotatedResult, 'check'>
 
 const STATUS_IN_PLAY = ['new', 'restored', 'resumed'] as GameState[]
-const STATUS_NOT_IN_PLAY = ['conceded', 'checkmate', 'stalemate', 'draw'] as GameState[]
+const STATUS_ENDED = ['conceded', 'checkmate', 'stalemate', 'draw'] as GameState[]
+const STATUS_AGREED = ['conceded', 'draw'] as GameState[]
 const STATUS_CAN_UNDO = [...STATUS_IN_PLAY, 'checkmate', 'stalemate'] as GameState[]
 
 interface GameStatus {
@@ -36,14 +29,51 @@ interface GameStatus {
   readonly victor: Side | 'none' | undefined 
 }
 
+const gameEndingToString = (s: GameStatus): string | undefined => {
+  let gameEnding = undefined
+  if (STATUS_ENDED.includes(s.state)) {
+    if (s.victor && s.victor !== 'none' ) {
+      gameEnding = GAMERESULT_SYMBOLS.victor[s.victor] 
+    }
+    else {
+      gameEnding = GAMERESULT_SYMBOLS.victor.draw  
+    }
+    if (s.state === 'conceded') {
+      gameEnding += GAMERESULT_SYMBOLS.concession
+    }
+    else if (s.state === 'draw') {
+      gameEnding += GAMERESULT_SYMBOLS.offer
+    }
+  }
+  return gameEnding
+}
+
+  // str will always be valid, since we produced it
+const gameEndingFromString = (str: string): GameStatus  => {
+
+  const victor: Side | 'none' = (str.startsWith(GAMERESULT_SYMBOLS.victor.draw)) ? 'none' :
+    str.startsWith(GAMERESULT_SYMBOLS.victor.white) ? 'white' : 'black';
+
+  let state: GameState
+  if (victor === 'none') {
+    state = (str.endsWith(GAMERESULT_SYMBOLS.offer)) ? 'draw' : 'stalemate'
+  }
+  else {
+    state = (str.endsWith(GAMERESULT_SYMBOLS.concession)) ? 'conceded' : 'checkmate'
+  }
+  return {
+    state,
+    victor
+  }
+}
+
 export { 
   type GameStatus as default,
-  type MoveResult,
-  MOVERESULT_FROM_SYMBOL,
-  MOVERESULT_SYMBOLS,
-  MOVERESULTS,
+  gameEndingToString,
+  gameEndingFromString,
   GAMERESULT_SYMBOLS,
   STATUS_IN_PLAY,
-  STATUS_NOT_IN_PLAY,
+  STATUS_ENDED,
+  STATUS_AGREED,
   STATUS_CAN_UNDO
 } 

--- a/just-the-chess/src/Piece.ts
+++ b/just-the-chess/src/Piece.ts
@@ -10,6 +10,8 @@ type PieceType =
   'knight' | 
   'king'
 
+type RookSide = 'kingside' | 'queenside' 
+
 interface Piece {
   readonly type: PieceType
   readonly side: Side
@@ -141,6 +143,7 @@ export {
   type PieceTypeCode,
   type PieceCode,
   type SideCode,
+  type RookSide,
   PRIMARY_PIECETYPES,
   isPrimaryType,
   SIDE_FROM_CODE,

--- a/just-the-chess/src/Resolution.ts
+++ b/just-the-chess/src/Resolution.ts
@@ -2,8 +2,8 @@ import type Action from './Action'
 import type Move from './Move'
 
   // Used to represent two notions:
-  // 1) a resolved move - action could be null 
-  // 2) a resolvable move - action will *not* be null
+  // 1) a resolved move: Resolved as an Action or null 
+  // 2) a resolvable move: Action will *not* be null by definition
 interface Resolution {
   readonly move: Move
   readonly action: Action | null

--- a/just-the-chess/src/game/Notifier.ts
+++ b/just-the-chess/src/game/Notifier.ts
@@ -2,7 +2,7 @@ import type ChessListener from '../ChessListener'
 import type Action from '../Action'
 import type { Side }  from '../Piece' 
 import type Move from '../Move' 
-import type ActionRecord from '../ActionRecord'
+import ActionRecord from '../ActionRecord'
 import type GameStatus from '../GameStatus'
 import type Check from '../Check'
 

--- a/just-the-chess/src/game/board/Tracking.ts
+++ b/just-the-chess/src/game/board/Tracking.ts
@@ -1,14 +1,14 @@
 import { makeObservable, observable, action } from 'mobx'
 
 import type CastlingTracking from '../../CastlingTracking'
-import type GameStatus from '../../GameStatus'
 import type Move from '../../Move'
 import type Position from '../../Position'
 import type Piece from '../../Piece'
 import { 
   isPrimaryType, 
   type PrimaryPieceType, 
-  type Side 
+  type Side, 
+  type RookSide
 } from '../../Piece'
 import { 
   positionFromString, 
@@ -18,11 +18,6 @@ import {
   type PositionCode 
 } from '../../Position'
 import type Snapshotable from '../../Snapshotable'
-
-const DEFAULT_GAME_STATUS: GameStatus = {
-  state: 'new',
-  victor: undefined
-}
 
 interface TrackingForSideSnapshot {
   king: PositionCode,
@@ -49,8 +44,6 @@ interface TrackingSnapshot {
   white: TrackingForSideSnapshot
   black: TrackingForSideSnapshot
 }
-
-
 
 class CastlingTrackingInternal 
   implements CastlingTracking, 
@@ -262,7 +255,7 @@ class TrackingForSide implements Snapshotable<TrackingForSideSnapshot> {
     this.castling.syncTo(source.castling)
   }
     // called when pos contains a rook
-  private _rookSideFromPosition(pos: Position): 'kingside' | 'queenside' {
+  private _rookSideFromPosition(pos: Position): RookSide {
     const { kingside, queenside } = this.primaries.rook
     if (kingside.position && positionsEqual(pos, kingside.position)) {
       return 'kingside'
@@ -273,7 +266,7 @@ class TrackingForSide implements Snapshotable<TrackingForSideSnapshot> {
     throw new Error( "Tracking._rookSideFromPosition(): could not determin rook side from position!")
   }
 
-  private _rookSideFromCapturePos(pos: Position): 'kingside' | 'queenside' {
+  private _rookSideFromCapturePos(pos: Position): RookSide {
     const { kingside, queenside } = this.primaries.rook
     if (kingside.capturePos && positionsEqual(pos, kingside.capturePos)) {
       return 'kingside'
@@ -299,7 +292,7 @@ class TrackingForSide implements Snapshotable<TrackingForSideSnapshot> {
     return [...this.primaries[t]]
   }
 
-  getRookTracking(rookSide: 'kingside' | 'queenside'): RookTracking {
+  getRookTracking(rookSide: RookSide): RookTracking {
     return this.primaries.rook[rookSide]
   }
 
@@ -431,7 +424,7 @@ class TrackingForSide implements Snapshotable<TrackingForSideSnapshot> {
       ****/
     const rank = m.from.rank
     let rook: {
-      rookSide: 'kingside' | 'queenside'
+      rookSide: RookSide
       from: Position
       to: Position
     } 
@@ -495,31 +488,20 @@ class Tracking implements Snapshotable<TrackingSnapshot>{
   white: TrackingForSide
   black: TrackingForSide
 
-    // Need to initialize for babel : https://github.com/mobxjs/mobx/issues/2486
-  gameStatus: GameStatus = DEFAULT_GAME_STATUS
 
   constructor(observeMe?: boolean) {
     this.white = new TrackingForSide('white', observeMe)
     this.black = new TrackingForSide('black', observeMe)
-    if (observeMe) {
-      makeObservable(this, {
-        gameStatus: observable.shallow,
-      })
-    }
   }
 
   reset() {
     this.white.reset('white')
     this.black.reset('black')
-    this.gameStatus = DEFAULT_GAME_STATUS
   }
 
   syncTo (source: Tracking) {
     this.white.syncTo(source.white)
     this.black.syncTo(source.black)
-      // https://mobx.js.org/observable-state.html#converting-observables-back-to-vanilla-javascript-collections
-      // always syncing from observable to non-observable
-    this.gameStatus = {...source.gameStatus}
   }
 
   takeSnapshot(): TrackingSnapshot {

--- a/just-the-chess/src/index.ts
+++ b/just-the-chess/src/index.ts
@@ -2,8 +2,7 @@
   // Only export what the apps actually import!
 export type { default as Action } from './Action'
 export { ACTIONS } from './Action'
-export type { default as ActionRecord} from './ActionRecord'
-export { actionRecordToLAN } from './ActionRecord'
+export { default as ActionRecord} from './ActionRecord'
 export type { default as CastlingTracking } from './CastlingTracking'
 export type { default as Check } from './Check'
 export type { default as ChessListener } from './ChessListener'


### PR DESCRIPTION
* _gameStatus is now in Game (not game._board._tracking)
* Turned ActionRecord into a class: made Move a member (rather an impled interface); moved to / from LAN string utils into it as member function and static var
* Removed _createActionRecord in favor of just calling the ActionRecord constructor
* MoveResult -> AnnotatedResult (in ActionRecord.tsx); Added 'gameEnding' string to persistence, from which a GameStatus can be rehydrated in cases where the game has ended
* Moved status change of squares based on incheck from game._notifyInCheck() to game._applyInCheck() which is called explicitly at the top level.  This is clearer and more reflective of what is actually happening
* Created type RookSide for 'kingside' | 'queenside'